### PR TITLE
Surface splitter errors on authors; ignore whitespace author_years

### DIFF
--- a/lib/taxonifi/splitter/builder.rb
+++ b/lib/taxonifi/splitter/builder.rb
@@ -1,4 +1,4 @@
-# Builder functionality for parsing/lexing framework. 
+# Builder functionality for parsing/lexing framework.
 module Taxonifi::Splitter::Builder
 
   # Load all builders (= models)
@@ -7,8 +7,11 @@ module Taxonifi::Splitter::Builder
 
   # Build and return Taxonifi::Model::AuthorYear from a string.
   def self.build_author_year(text)
-    lexer = Taxonifi::Splitter::Lexer.new(text)
+    text = text&.strip
     builder = Taxonifi::Model::AuthorYear.new
+    return builder if text.nil? || text.empty?
+
+    lexer = Taxonifi::Splitter::Lexer.new(text)
     Taxonifi::Splitter::Parser.new(lexer, builder).parse_author_year
     builder
   end


### PR DESCRIPTION
Two changes:
* ignore whitespace author_years (' ')
* surface errors that arise from parse errors on `author_year` in `Lumper.create_name_collection` (I've ignored for now two other locations that call `Taxonifi::Splitter::Builder.build_author_year` - those will need their own handling as necessary). Example error-causing string: ')Smith)'.

See unit tests for examples.